### PR TITLE
refactor: run each 2smr analysis instead of generating a md report

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -160,46 +160,31 @@ workflow {
     TWOSAMPLEMR.out.mrpresso
         .collectFile(name: 'concatenated_mrpresso.txt', storeDir: "${params.outdir}/collected_files/")
         .set { concatenated_mrpresso }
+    
+    TWOSAMPLEMR.out.metrics
+        .collectFile(name: 'concatenated_metrics.txt', storeDir: "${params.outdir}/collected_files/")
+        .set { concatenated_metrics }
 
-    PARSE_2SMR (
-	    TWOSAMPLEMR.out.report
-	    )
+    TWOSAMPLEMR.out.steiger
+        .collectFile(name: 'concatenated_steiger.txt', storeDir: "${params.outdir}/collected_files/")
+        .set { concatenated_steiger }
 
-    ADD_H_COLUMN (
-	    PARSE_2SMR.out.results_heterogeneity,
-    )
-    ADD_H_COLUMN.out.formatted_report
-        .collectFile(name: 'concatenated_h.csv', skip: 1, storeDir: "${params.outdir}/collected_files/")
-        .set { concatenated_h }
+    TWOSAMPLEMR.out.heterogeneity
+        .collectFile(name: 'concatenated_heterogeneity.txt', storeDir: "${params.outdir}/collected_files/")
+        .set { concatenated_heterogeneity }
 
-    ADD_S_COLUMN (
-	    PARSE_2SMR.out.results_steiger,
-    )
-    ADD_S_COLUMN.out.formatted_report
-        .collectFile(name: 'concatenated_s.csv', skip: 1, storeDir: "${params.outdir}/collected_files/")
-        .set { concatenated_s }
+    TWOSAMPLEMR.out.pleiotropy
+        .collectFile(name: 'concatenated_pleiotropy.txt', storeDir: "${params.outdir}/collected_files/")
+        .set { concatenated_pleiotropy }
 
-    ADD_P_COLUMN (
-	    PARSE_2SMR.out.results_pleiotropy,
-    )
-    ADD_P_COLUMN.out.formatted_report
-        .collectFile(name: 'concatenated_p.csv', skip: 1, storeDir: "${params.outdir}/collected_files/")
-        .set { concatenated_p }
-
-    ADD_M_COLUMN (
-	    PARSE_2SMR.out.results_metrics,
-    )
-    ADD_M_COLUMN.out.formatted_report
-        .collectFile(name: 'concatenated_m.csv', skip: 1, storeDir: "${params.outdir}/collected_files/")
-        .set { concatenated_m }
 
     RESULT (
 	    concatenated_coloc,
             GSMR_FILTER.out.filtered_genes,
-            concatenated_h,
-            concatenated_s,
-            concatenated_p,
-            concatenated_m,
+            concatenated_heterogeneity,
+            concatenated_steiger,
+            concatenated_pleiotropy,
+            concatenated_metrics,
             concatenated_mrpresso
     )
 

--- a/modules/local/twosamplemr/tsmr.nf
+++ b/modules/local/twosamplemr/tsmr.nf
@@ -13,11 +13,13 @@ process TWOSAMPLEMR {
     path(reference)
 
   output:
-    path("*md")              , emit: report
-    path("*csv")             , emit: data
-    path("figure")           , emit: figures
-    path("*png")             , emit: effplot
-    path("*mrpresso*")       , emit: mrpresso
+    path("*pleiotropy.txt")              , emit: pleiotropy
+    path("*metrics.txt")                 , emit: metrics
+    path("*heterogeneity.txt")           , emit: heterogeneity
+    path("*steiger.txt")                 , emit: steiger
+    path("*rsquare.txt")                 , emit: rsquare
+    path("*png")                         , emit: effplot
+    path("*mrpresso.txt")                , emit: mrpresso
   
   when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
Previously, the TwoSampleMR module generated a markdown report with the results of a list of analyses, which required an additional five modules just to parse the data to the results module. I used the isolated analyses functions from 2smr package and outputted in the format read by the report module, so that 5 modules are not necessary.
I made several changes (in a single commit, sorry 😬 ) to do this, and additionally, I changed the TwoSampleMR effect plot (image size, font size, and plot theme).
To test this, run with -profile test and check if: 1- The effect plot is correctly shown on the markdown report 2- The candidate genes (NEGR1 and NT5C2) are still pointed as the ones.