### PR TITLE
Add qtl filter module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -30,6 +30,7 @@ process {
     }
 
     withName:TWOSAMPLEMR {
+        errorStrategy = { 'ignore' }
         publishDir = [path: { "${params.outdir}/twosamplemr/" }, mode: 'copy']
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -30,7 +30,6 @@ process {
     }
 
     withName:TWOSAMPLEMR {
-        errorStrategy = { 'ignore' }
         publishDir = [path: { "${params.outdir}/twosamplemr/" }, mode: 'copy']
     }
 

--- a/main.nf
+++ b/main.nf
@@ -13,7 +13,7 @@ include { fromSamplesheet; validateParameters } from 'plugin/nf-validation'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-
+include { QTL_FILTER } from "./modules/local/qtl_filter/qtl_filter.nf"
 include { TWOSAMPLEMR } from "./modules/local/twosamplemr/tsmr.nf"
 include { COLOC } from "./modules/local/coloc/coloc.nf"
 include { GCTA_GSMR } from "./modules/local/gsmr/gsmr.nf"
@@ -94,13 +94,13 @@ workflow {
             zenodo_ref
         )
 
-        ref = UNTAR_REF.out.untar.map { it[1] } + "/ref/"
+        ref = UNTAR_REF.out.untar.map { it[1] } 
 
         bim_files = UNTAR_REF.out.untar
             .map { meta, path -> 
-                def bim = file("${path}/ref/*.bim")
+                def bim = file("${path}/*.bim")
                 if (bim.isEmpty()) {
-                    error "No .bim file found in ${path}/ref/"
+                    error "No .bim file found in ${path}/"
                 }
                 [meta, bim[0]]  // We're assuming there's only one .bim file
             }
@@ -114,25 +114,48 @@ workflow {
              zenodo_ref
          )
  
-         ref = UNTAR_REF.out.untar.map { it[1] } + "/ref/"
+         ref = UNTAR_REF.out.untar.map { it[1] }
  
          bim_files = UNTAR_REF.out.untar
              .map { meta, path ->
-                 def bim = file("${path}/ref/*.bim")
+                 def bim = file("${path}/*.bim")
                  if (bim.isEmpty()) {
-                     error "No .bim file found in ${path}/ref/"
+                     error "No .bim file found in ${path}/"
                  }
                  [meta, bim[0]]  // We're assuming there's only one .bim file
              }
              .map { it[1] }
  
      }
+    
+    QTL_FILTER (
+        data,
+        params.p_clump
+    )
 
-    data.combine(outcomes).set { og_combinations }
+    QTL_FILTER.out.filtered_sumstats
+        .branch {
+            pass: it[2] == "true"
+            fail: it[2] == "false"
+        }
+        .set { filter_result }
+    
+    // Continue with passed QTLs
+    filter_result.pass
+        .map { meta, sumstats, pass_filter -> [meta, sumstats] }
+        .set { passed_qtls }
+
+    passed_qtls.view { meta, sumstats -> 
+        "Passed QTL - Meta: $meta, Sumstats: $sumstats.name"
+    }
+
+    //Combine qlt_filter.out with outcomes
+    passed_qtls.combine(outcomes).set { og_combinations }
+
     GCTA_GSMR (
-      og_combinations,
-	  ref,
-          params.p_clump
+        og_combinations,
+	ref,
+        params.p_clump
     )
 
     GCTA_MERGE_ERR(GCTA_GSMR.out.gsmr_err.collect())

--- a/main.nf
+++ b/main.nf
@@ -94,13 +94,13 @@ workflow {
             zenodo_ref
         )
 
-        ref = UNTAR_REF.out.untar.map { it[1] } 
+        ref = UNTAR_REF.out.untar.map { it[1] } + "/ref/" 
 
         bim_files = UNTAR_REF.out.untar
             .map { meta, path -> 
-                def bim = file("${path}/*.bim")
+                def bim = file("${path}/ref/*.bim")
                 if (bim.isEmpty()) {
-                    error "No .bim file found in ${path}/"
+                    error "No .bim file found in ${path}/ref/"
                 }
                 [meta, bim[0]]  // We're assuming there's only one .bim file
             }
@@ -114,13 +114,13 @@ workflow {
              zenodo_ref
          )
  
-         ref = UNTAR_REF.out.untar.map { it[1] }
+         ref = UNTAR_REF.out.untar.map { it[1] } + "/ref/"
  
          bim_files = UNTAR_REF.out.untar
              .map { meta, path ->
-                 def bim = file("${path}/*.bim")
+                 def bim = file("${path}/ref/*.bim")
                  if (bim.isEmpty()) {
-                     error "No .bim file found in ${path}/"
+                     error "No .bim file found in ${path}/ref/"
                  }
                  [meta, bim[0]]  // We're assuming there's only one .bim file
              }
@@ -144,10 +144,6 @@ workflow {
     filter_result.pass
         .map { meta, sumstats, pass_filter -> [meta, sumstats] }
         .set { passed_qtls }
-
-    passed_qtls.view { meta, sumstats -> 
-        "Passed QTL - Meta: $meta, Sumstats: $sumstats.name"
-    }
 
     //Combine qlt_filter.out with outcomes
     passed_qtls.combine(outcomes).set { og_combinations }

--- a/modules/local/gsmr/gsmr.nf
+++ b/modules/local/gsmr/gsmr.nf
@@ -4,6 +4,8 @@ process GCTA_GSMR {
     container "${ workflow.containerEngine == 'singularity' ? 'docker://quay.io/biocontainers/gcta:1.94.1--h9ee0642_0':
               'quay.io/biocontainers/gcta:1.94.1--h9ee0642_0' }"
 
+    stageInMode 'copy'
+
     input: 
     tuple val(meta), path(exposure), val(meta2), path(outcome)
     path(reference)

--- a/modules/local/qtl_filter/qtl_filter.nf
+++ b/modules/local/qtl_filter/qtl_filter.nf
@@ -1,8 +1,8 @@
 process QTL_FILTER {
     label 'process_low'
 
-    container "${ workflow.containerEngine == 'singularity' ? 'docker://juliaapolonio/ubuntu-wget:latest':
-            'docker.io/juliaapolonio/ubuntu-wget:latest' }"
+    container "${ workflow.containerEngine == 'singularity' ? 'docker://juliaapolonio/qtl_filter:v1.0':
+            'docker.io/juliaapolonio/qtl_filter:v1.0' }"
 
     input:
     tuple val(meta), path(sumstats)
@@ -22,26 +22,15 @@ process QTL_FILTER {
     set -euo pipefail
 
 
-    echo "Debug: Input file is ${sumstats}"
-    echo "Debug: p_clump value is ${p_clump}"
-
     # Check if the file is gzipped
     if file ${sumstats} | grep -q gzip; then
-        echo "Debug: File is gzipped"
         cat_cmd="zcat"
     else
-        echo "Debug: File is not gzipped"
         cat_cmd="cat"
     fi
 
-    # Print the first few lines of the file for debugging
-    echo "Debug: First few lines of the file:"
-    \$cat_cmd ${sumstats} | head -n 5
-
     # Find the minimum p-value in the 7th column
     min_pval=\$(\$cat_cmd ${sumstats} | awk 'NR>1 && \$7!="" {if(\$7+0<min || min=="") min=\$7+0} END {print (min==""?"NA":min)}')
-
-    echo "Debug: Minimum p-value found: \$min_pval"
 
     # Check if the minimum p-value is smaller than p_clump
     if [ "\$min_pval" != "NA" ] && (( \$(echo "\${min_pval} < ${p_clump}" | bc -l) )); then
@@ -50,9 +39,6 @@ process QTL_FILTER {
         pass_filter="false"
     fi
 
-    echo "Debug: pass_filter value: \$pass_filter"
-
-    # Output the pass_filter value
     echo "pass_filter=\$pass_filter"
 
     """

--- a/modules/local/qtl_filter/qtl_filter.nf
+++ b/modules/local/qtl_filter/qtl_filter.nf
@@ -1,0 +1,60 @@
+process QTL_FILTER {
+    label 'process_low'
+
+    container "${ workflow.containerEngine == 'singularity' ? 'docker://juliaapolonio/ubuntu-wget:latest':
+            'docker.io/juliaapolonio/ubuntu-wget:latest' }"
+
+    input:
+    tuple val(meta), path(sumstats)
+    val(p_clump)
+
+    output:
+    tuple val(meta), path(sumstats), env(pass_filter), emit: filtered_sumstats
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    
+    """
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+
+    echo "Debug: Input file is ${sumstats}"
+    echo "Debug: p_clump value is ${p_clump}"
+
+    # Check if the file is gzipped
+    if file ${sumstats} | grep -q gzip; then
+        echo "Debug: File is gzipped"
+        cat_cmd="zcat"
+    else
+        echo "Debug: File is not gzipped"
+        cat_cmd="cat"
+    fi
+
+    # Print the first few lines of the file for debugging
+    echo "Debug: First few lines of the file:"
+    \$cat_cmd ${sumstats} | head -n 5
+
+    # Find the minimum p-value in the 7th column
+    min_pval=\$(\$cat_cmd ${sumstats} | awk 'NR>1 && \$7!="" {if(\$7+0<min || min=="") min=\$7+0} END {print (min==""?"NA":min)}')
+
+    echo "Debug: Minimum p-value found: \$min_pval"
+
+    # Check if the minimum p-value is smaller than p_clump
+    if [ "\$min_pval" != "NA" ] && (( \$(echo "\${min_pval} < ${p_clump}" | bc -l) )); then
+        pass_filter="true"
+    else
+        pass_filter="false"
+    fi
+
+    echo "Debug: pass_filter value: \$pass_filter"
+
+    # Output the pass_filter value
+    echo "pass_filter=\$pass_filter"
+
+    """
+
+}

--- a/modules/local/qtl_filter/qtl_filter.nf
+++ b/modules/local/qtl_filter/qtl_filter.nf
@@ -1,5 +1,5 @@
 process QTL_FILTER {
-    label 'process_low'
+    label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' ? 'docker://juliaapolonio/qtl_filter:v1.0':
             'docker.io/juliaapolonio/qtl_filter:v1.0' }"


### PR DESCRIPTION
Added a new module that looks into each QTL file and remove if it has no SNP with pvalue smaller than p_clump. This is to avoid "not enough SNPs" error in GSMR and speed up the pipeline, specially with low power QTLs.

Test: run using test profile; it should remove 1 of the 4 sumstats (qtl_filter step should have 4 tasks and gcta_gsmr should have 3). All the rest should work as previously would.